### PR TITLE
Add config mgmt resources to IaaC section

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,13 @@ Download [PDF version](DevOps%20Roadmap.pdf).
 - [Automate Terraform documentation like a pro!](https://medium.com/google-cloud/automate-terraform-documentation-like-a-pro-ed3e19998808) <sup>FREE</sup>
 - [Writing reusable Terraform modules](https://thomasthornton.cloud/2022/06/02/writing-reusable-terraform-modules/) <sup>FREE</sup>
 - [What is Istio?](https://www.redhat.com/en/topics/microservices/what-is-istio) <sup>FREE</sup>
+- [Puppet overview](https://puppet.com/docs/puppet/latest/puppet_overview.html) <sup>FREE</sup>
+- [Puppet Courses](https://training.puppet.com/) <sup>FREE and PAID</sup>
+- [Getting Started With Ansible](https://docs.ansible.com/ansible/latest/getting_started/) <sup>FREE</sup>
+- [Learning Ansible Basics](https://www.redhat.com/en/topics/automation/learning-ansible-tutorial)
+- [Get started with Red Hat Ansible](https://www.ansible.com/resources/get-started) <sup>FREE and PAID</sup>
+- [Mastering Ansible](https://www.udemy.com/course/mastering-ansible/) <sup>Udemy Course</sup>
+- [Learn Chef](https://learn.chef.io/) <sup>FREE</sup>
 
 ### 9. Learn CI/CD
 


### PR DESCRIPTION
Noticed that there wasn't any resources for the most popular configuration management tools (though diagram has a couple mentioned). Seems like Infrastructure as Code section is right place for these.