### PR TITLE
Add FailureMemory to GitHub Actions resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ Some **popular CI/CD tools** are: Jenkins, TeamCity, CircleCI, Bamboo, GitLab, a
     - [Learn GitHub actions](https://learn.microsoft.com/en-us/users/githubtraining/collections/n5p4a5z7keznp5) <sup>FREE</sup>
     - [GitHub Actions Tutorial by Tech World with Nana](https://www.youtube.com/watch?v=R8_veQiYBjI) <sup>FREE</sup>
     - [Workflow syntax for GitHub Actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions) <sup>FREE</sup>
+    - [FailureMemory](https://github.com/UnguisAI/failurememory) - GitHub Action for recurring CI failure fingerprinting and memory-backed triage.
 - GitLab:
     - [Learn GitLab with tutorials](https://docs.gitlab.com/ee/tutorials/) <sup>FREE</sup>
     - [GitLab CI CD Tutorial for Beginners by Tech World With Nana](https://www.youtube.com/watch?v=qP8kir2GUgo) <sup>FREE</sup>


### PR DESCRIPTION
## Summary

- add FailureMemory to the GitHub Actions resources list in the CI/CD section
- keep the change limited to one README resource entry

## Why

FailureMemory is a GitHub Action for recurring CI failure fingerprinting and memory-backed triage. It helps maintainers recognize repeated GitHub Actions failures and shorten re-triage work instead of re-reading the same CI noise from scratch.