### PR TITLE
docs: update Python Crash Course link

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Here you need to learn basic concepts of programming languages, such as syntax, 
 
 - Python:
   - [Automate the Boring Stuff with Python book](https://automatetheboringstuff.com/) <sup>FREE</sup>
-  - [Python Crash Course](https://ehmatthes.github.io/pcc/) <sup>FREE</sup>
+  - [Python Crash Course](https://ehmatthes.github.io/pcc_3e/) <sup>FREE</sup>
 - JavaScript:
   - [The Modern JavaScript Tutorial](https://javascript.info/) <sup>FREE</sup>
   - [JavaScript Crash Course For Beginners](https://www.youtube.com/watch?v=hdI2bqOjy3c) <sup>FREE</sup>


### PR DESCRIPTION
Updates the Python Crash Course link in README.md to the Third Edition website.

Old: https://ehmatthes.github.io/pcc/
New: https://ehmatthes.github.io/pcc_3e/